### PR TITLE
Remove alpha tensorflow dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,9 @@ setuptools.setup(
         'matplotlib>=3.1',
         'numpy>=1.17',
         'pandas>=1.0.0, <1.1.0',
-        'scipy==1.4.1',  # Tensorfow 2.2 depends
-        'tensorflow>=2.2.0, <2.4.0',
-        'tensorflow-probability>=0.9',
-        'tensorflow-addons>=0.7.1'
+        'scipy>=1.4.1', #We need to check for direct depends or we can delete scipy.
+        'tensorflow>=2.3.0, <2.4.0',
+        'tensorflow-probability>=0.11.0',
+        'tensorflow-addons>=0.11.0'
         ]
 )


### PR DESCRIPTION
Tensorflow 2.3.0 has been released. Remove scipy 1.4.1 lock and pandas lock

https://github.com/tensorflow/tensorflow/commit/78026d6a66f7f0fc80c69b1a2f8843616f4cd2a7#diff-739fc4f018f5288972ae5826b15c36e7