### PR TITLE
Remove the arbitary version lock on baynesian quilt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ setuptools.setup(
         'tensorflow>=2.4.0',
         'tensorflow-probability>=0.12.1',
         'tensorflow-addons>=0.12.0',
-        'bayesianquilts@git+https://github.com/mederrata/bayesianquilts.git#egg=bayesianquilts-0.0.1'
+        'bayesianquilts@git+https://github.com/mederrata/bayesianquilts.git'
     ],
     dependency_links=[
-        "git+https://github.com/mederrata/bayesianquilts.git#egg=bayesianquilts-0.0.1",
+        "git+https://github.com/mederrata/bayesianquilts.git",
     ]
 )


### PR DESCRIPTION

pip install .
Processing /Users/psuedofinnish/git_repo/spmf
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
Collecting bayesianquilts@ git+https://github.com/mederrata/bayesianquilts.git
  Cloning https://github.com/mederrata/bayesianquilts.git to /private/var/folders/lm/dchvrvv15dz87prf3k97fdfw0000gn/T/pip-install-36tu_ya6/bayesianquilts_5012914572444791ad4327f0220afd0a
  Running command git clone -q https://github.com/mederrata/bayesianquilts.git /private/var/folders/lm/dchvrvv15dz87prf3k97fdfw0000gn/T/pip-install-36tu_ya6/bayesianquilts_5012914572444791ad4327f0220afd0a
  Resolved https://github.com/mederrata/bayesianquilts.git to commit c6b8ea17bb1d04107074bb12e525c496e4a247c9
Collecting dill>=0.3.1.1
  Using cached dill-0.3.4-py2.py3-none-any.whl (86 kB)
Collecting matplotlib>=3.1
  Using cached matplotlib-3.4.3-cp39-cp39-macosx_10_9_x86_64.whl (7.2 MB)
Collecting arviz>=0.10.0
  Using cached arviz-0.11.4-py3-none-any.whl (1.6 MB)
Collecting numpy>=1.17
  Using cached numpy-1.21.2-cp39-cp39-macosx_10_9_x86_64.whl (17.0 MB)
Collecting pandas<1.2.0,>=1.0.0
  Using cached pandas-1.1.5-cp39-cp39-macosx_10_9_x86_64.whl (10.3 MB)
Collecting scipy>=1.4.1
  Using cached scipy-1.7.1-cp39-cp39-macosx_10_9_x86_64.whl (32.8 MB)
Collecting tensorflow>=2.4.0
  Using cached tensorflow-2.6.0-cp39-cp39-macosx_10_11_x86_64.whl (199.0 MB)
Collecting tensorflow-probability>=0.12.1
  Using cached tensorflow_probability-0.14.1-py2.py3-none-any.whl (5.7 MB)
Collecting tensorflow-addons>=0.12.0
  Using cached tensorflow_addons-0.14.0-cp39-cp39-macosx_10_13_x86_64.whl (575 kB)
Collecting packaging
  Using cached packaging-21.0-py3-none-any.whl (40 kB)
Collecting typing-extensions<4,>=3.7.4.3
  Using cached typing_extensions-3.10.0.2-py3-none-any.whl (26 kB)
Requirement already satisfied: setuptools>=38.4 in ./venv/lib/python3.9/site-packages (from arviz>=0.10.0->mederrata-spmf==0.0.1) (57.4.0)
Collecting netcdf4
  Using cached netCDF4-1.5.7-cp39-cp39-macosx_10_9_x86_64.whl (4.0 MB)
Collecting xarray>=0.16.1
  Using cached xarray-0.19.0-py3-none-any.whl (827 kB)
Collecting pyparsing>=2.2.1
  Using cached pyparsing-2.4.7-py2.py3-none-any.whl (67 kB)
Collecting cycler>=0.10
  Using cached cycler-0.10.0-py2.py3-none-any.whl (6.5 kB)
Collecting pillow>=6.2.0
  Using cached Pillow-8.3.2-cp39-cp39-macosx_10_10_x86_64.whl (3.0 MB)
Collecting python-dateutil>=2.7
  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Collecting kiwisolver>=1.0.1
  Using cached kiwisolver-1.3.2-cp39-cp39-macosx_10_9_x86_64.whl (61 kB)
Collecting six
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting pytz>=2017.2
  Using cached pytz-2021.3-py2.py3-none-any.whl (503 kB)
Collecting absl-py~=0.10
  Using cached absl_py-0.14.1-py3-none-any.whl (131 kB)
Collecting grpcio<2.0,>=1.37.0
  Using cached grpcio-1.41.0-cp39-cp39-macosx_10_10_x86_64.whl (3.9 MB)
Collecting clang~=5.0
  Using cached clang-5.0.tar.gz (30 kB)
Collecting tensorflow-estimator~=2.6
  Using cached tensorflow_estimator-2.6.0-py2.py3-none-any.whl (462 kB)
Collecting typing-extensions<4,>=3.7.4.3
  Using cached typing_extensions-3.7.4.3-py3-none-any.whl (22 kB)
Collecting keras~=2.6
  Using cached keras-2.6.0-py2.py3-none-any.whl (1.3 MB)
Collecting keras-preprocessing~=1.1.2
  Using cached Keras_Preprocessing-1.1.2-py2.py3-none-any.whl (42 kB)
Collecting h5py~=3.1.0
  Using cached h5py-3.1.0-cp39-cp39-macosx_10_9_x86_64.whl (2.9 MB)
Collecting termcolor~=1.1.0
  Using cached termcolor-1.1.0.tar.gz (3.9 kB)
Collecting astunparse~=1.6.3
  Using cached astunparse-1.6.3-py2.py3-none-any.whl (12 kB)
Requirement already satisfied: wheel~=0.35 in ./venv/lib/python3.9/site-packages (from tensorflow>=2.4.0->mederrata-spmf==0.0.1) (0.37.0)
Collecting opt-einsum~=3.3.0
  Using cached opt_einsum-3.3.0-py3-none-any.whl (65 kB)
Collecting google-pasta~=0.2
  Using cached google_pasta-0.2.0-py3-none-any.whl (57 kB)
Collecting numpy>=1.17
  Using cached numpy-1.19.5-cp39-cp39-macosx_10_9_x86_64.whl (15.6 MB)
Collecting six
  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
Collecting tensorboard~=2.6
  Using cached tensorboard-2.6.0-py3-none-any.whl (5.6 MB)
Collecting gast==0.4.0
  Using cached gast-0.4.0-py3-none-any.whl (9.8 kB)
Collecting wrapt~=1.12.1
  Using cached wrapt-1.12.1.tar.gz (27 kB)
Collecting flatbuffers~=1.12.0
  Using cached flatbuffers-1.12-py2.py3-none-any.whl (15 kB)
Collecting protobuf>=3.9.2
  Using cached protobuf-3.18.1-cp39-cp39-macosx_10_9_x86_64.whl (1.0 MB)
Collecting tensorboard-data-server<0.7.0,>=0.6.0
  Using cached tensorboard_data_server-0.6.1-py3-none-macosx_10_9_x86_64.whl (3.5 MB)
Collecting markdown>=2.6.8
  Using cached Markdown-3.3.4-py3-none-any.whl (97 kB)
Collecting werkzeug>=0.11.15
  Using cached Werkzeug-2.0.2-py3-none-any.whl (288 kB)
Collecting tensorboard-plugin-wit>=1.6.0
  Using cached tensorboard_plugin_wit-1.8.0-py3-none-any.whl (781 kB)
Collecting google-auth-oauthlib<0.5,>=0.4.1
  Using cached google_auth_oauthlib-0.4.6-py2.py3-none-any.whl (18 kB)
Collecting google-auth<2,>=1.6.3
  Using cached google_auth-1.35.0-py2.py3-none-any.whl (152 kB)
Requirement already satisfied: requests<3,>=2.21.0 in ./venv/lib/python3.9/site-packages (from tensorboard~=2.6->tensorflow>=2.4.0->mederrata-spmf==0.0.1) (2.26.0)
Collecting pyasn1-modules>=0.2.1
  Using cached pyasn1_modules-0.2.8-py2.py3-none-any.whl (155 kB)
Collecting rsa<5,>=3.1.4
  Using cached rsa-4.7.2-py3-none-any.whl (34 kB)
Collecting cachetools<5.0,>=2.0.0
  Using cached cachetools-4.2.4-py3-none-any.whl (10 kB)
Collecting requests-oauthlib>=0.7.0
  Using cached requests_oauthlib-1.3.0-py2.py3-none-any.whl (23 kB)
Collecting pyasn1<0.5.0,>=0.4.6
  Using cached pyasn1-0.4.8-py2.py3-none-any.whl (77 kB)
Requirement already satisfied: certifi>=2017.4.17 in ./venv/lib/python3.9/site-packages (from requests<3,>=2.21.0->tensorboard~=2.6->tensorflow>=2.4.0->mederrata-spmf==0.0.1) (2021.10.8)
Requirement already satisfied: idna<4,>=2.5 in ./venv/lib/python3.9/site-packages (from requests<3,>=2.21.0->tensorboard~=2.6->tensorflow>=2.4.0->mederrata-spmf==0.0.1) (3.3)
Requirement already satisfied: charset-normalizer~=2.0.0 in ./venv/lib/python3.9/site-packages (from requests<3,>=2.21.0->tensorboard~=2.6->tensorflow>=2.4.0->mederrata-spmf==0.0.1) (2.0.7)
Requirement already satisfied: urllib3<1.27,>=1.21.1 in ./venv/lib/python3.9/site-packages (from requests<3,>=2.21.0->tensorboard~=2.6->tensorflow>=2.4.0->mederrata-spmf==0.0.1) (1.26.7)
Collecting oauthlib>=3.0.0
  Using cached oauthlib-3.1.1-py2.py3-none-any.whl (146 kB)
Collecting typeguard>=2.7
  Using cached typeguard-2.13.0-py3-none-any.whl (17 kB)
Collecting decorator
  Using cached decorator-5.1.0-py3-none-any.whl (9.1 kB)
Collecting cloudpickle>=1.3
  Using cached cloudpickle-2.0.0-py3-none-any.whl (25 kB)
Collecting dm-tree
  Using cached dm_tree-0.1.6-cp39-cp39-macosx_10_14_x86_64.whl (95 kB)
Collecting jax
  Using cached jax-0.2.22.tar.gz (776 kB)
Collecting jaxlib
  Using cached jaxlib-0.1.72-cp39-none-macosx_10_9_x86_64.whl (44.1 MB)
Collecting natsort
  Using cached natsort-7.1.1-py3-none-any.whl (35 kB)
Collecting tqdm
  Using cached tqdm-4.62.3-py2.py3-none-any.whl (76 kB)
Collecting cftime
  Using cached cftime-1.5.1-cp39-cp39-macosx_10_9_x86_64.whl (222 kB)
Building wheels for collected packages: mederrata-spmf, clang, termcolor, wrapt, bayesianquilts, jax
  Building wheel for mederrata-spmf (setup.py) ... done
  Created wheel for mederrata-spmf: filename=mederrata_spmf-0.0.1-py3-none-any.whl size=11849 sha256=849f8a917f99c7d6aeb525805554951de6d25b2ede3f7d5fb3c7531ba68ee058
  Stored in directory: /private/var/folders/lm/dchvrvv15dz87prf3k97fdfw0000gn/T/pip-ephem-wheel-cache-t48whcux/wheels/e0/24/c6/9e5c18c271ea71c12b85be41b6bf40c7409cce1cf8c134eeb5
  Building wheel for clang (setup.py) ... done
  Created wheel for clang: filename=clang-5.0-py3-none-any.whl size=30692 sha256=5555e1cf8cb334404c8722c1e5dee33144ec58a27673df42f6cb8cd7f9d169d0
  Stored in directory: /Users/psuedofinnish/Library/Caches/pip/wheels/3a/ce/7a/27094f689461801c934296d07078773603663dfcaca63bb064
  Building wheel for termcolor (setup.py) ... done
  Created wheel for termcolor: filename=termcolor-1.1.0-py3-none-any.whl size=4847 sha256=f8a2068c8913078bcb784f39c2296ed39b91a96b539fa38c742507b228f52627
  Stored in directory: /Users/psuedofinnish/Library/Caches/pip/wheels/b6/0d/90/0d1bbd99855f99cb2f6c2e5ff96f8023fad8ec367695f7d72d
  Building wheel for wrapt (setup.py) ... done
  Created wheel for wrapt: filename=wrapt-1.12.1-cp39-cp39-macosx_11_0_x86_64.whl size=32856 sha256=cb38cbfd0ba82006e73eb83267c9da7ee2bc45745ab8fde52215a1d60780b7aa
  Stored in directory: /Users/psuedofinnish/Library/Caches/pip/wheels/98/23/68/efe259aaca055e93b08e74fbe512819c69a2155c11ba3c0f10
  Building wheel for bayesianquilts (setup.py) ... done
  Created wheel for bayesianquilts: filename=bayesianquilts-0.0.6-py3-none-any.whl size=24180 sha256=af9409fdeef2184c5a018b0a130e3c0f0379a6bb983f9591fa3a21a54664711c
  Stored in directory: /private/var/folders/lm/dchvrvv15dz87prf3k97fdfw0000gn/T/pip-ephem-wheel-cache-t48whcux/wheels/51/9d/a7/d49d7fa318720372b80b0f9bc6f1122b58262830a84d70dcf6
  Building wheel for jax (setup.py) ... done
  Created wheel for jax: filename=jax-0.2.22-py3-none-any.whl size=890292 sha256=7d6ff6dc027545c6efe8288ff40ad194713038c5dd6f10b8805310b51a1cb0dd
  Stored in directory: /Users/psuedofinnish/Library/Caches/pip/wheels/01/28/1b/5d30b3b33d4fba11a21e17b9262042b200233bec10b696cbbe
Successfully built mederrata-spmf clang termcolor wrapt bayesianquilts jax
Installing collected packages: pyasn1, six, rsa, pyasn1-modules, oauthlib, cachetools, requests-oauthlib, pytz, python-dateutil, numpy, google-auth, werkzeug, tensorboard-plugin-wit, tensorboard-data-server, pyparsing, protobuf, pillow, pandas, markdown, kiwisolver, grpcio, google-auth-oauthlib, cycler, cftime, absl-py, xarray, wrapt, typing-extensions, typeguard, termcolor, tensorflow-estimator, tensorboard, scipy, packaging, opt-einsum, netcdf4, matplotlib, keras-preprocessing, keras, h5py, google-pasta, gast, flatbuffers, dm-tree, decorator, cloudpickle, clang, astunparse, tqdm, tensorflow-probability, tensorflow-addons, tensorflow, natsort, jaxlib, jax, dill, arviz, bayesianquilts, mederrata-spmf
Successfully installed absl-py-0.14.1 arviz-0.11.4 astunparse-1.6.3 bayesianquilts-0.0.6 cachetools-4.2.4 cftime-1.5.1 clang-5.0 cloudpickle-2.0.0 cycler-0.10.0 decorator-5.1.0 dill-0.3.4 dm-tree-0.1.6 flatbuffers-1.12 gast-0.4.0 google-auth-1.35.0 google-auth-oauthlib-0.4.6 google-pasta-0.2.0 grpcio-1.41.0 h5py-3.1.0 jax-0.2.22 jaxlib-0.1.72 keras-2.6.0 keras-preprocessing-1.1.2 kiwisolver-1.3.2 markdown-3.3.4 matplotlib-3.4.3 mederrata-spmf-0.0.1 natsort-7.1.1 netcdf4-1.5.7 numpy-1.19.5 oauthlib-3.1.1 opt-einsum-3.3.0 packaging-21.0 pandas-1.1.5 pillow-8.3.2 protobuf-3.18.1 pyasn1-0.4.8 pyasn1-modules-0.2.8 pyparsing-2.4.7 python-dateutil-2.8.2 pytz-2021.3 requests-oauthlib-1.3.0 rsa-4.7.2 scipy-1.7.1 six-1.15.0 tensorboard-2.6.0 tensorboard-data-server-0.6.1 tensorboard-plugin-wit-1.8.0 tensorflow-2.6.0 tensorflow-addons-0.14.0 tensorflow-estimator-2.6.0 tensorflow-probability-0.14.1 termcolor-1.1.0 tqdm-4.62.3 typeguard-2.13.0 typing-extensions-3.7.4.3 werkzeug-2.0.2 wrapt-1.12.1 xarray-0.19.0
WARNING: You are using pip version 21.2.4; however, version 21.3 is available.
You should consider upgrading via the '/Users/psuedofinnish/git_repo/spmf/venv/bin/python3.9 -m pip install --upgrade pip' command.
(venv) ➜  spmf git:(remove_version_lock) ✗ pip list
Package                 Version
----------------------- ---------
absl-py                 0.14.1
arviz                   0.11.4
astunparse              1.6.3
bayesianquilts          0.0.6
cachetools              4.2.4
certifi                 2021.10.8
cftime                  1.5.1
charset-normalizer      2.0.7
clang                   5.0
cloudpickle             2.0.0
cPython                 0.0.6
cycler                  0.10.0
decorator               5.1.0
dill                    0.3.4
dm-tree                 0.1.6
flatbuffers             1.12
gast                    0.4.0
google-auth             1.35.0
google-auth-oauthlib    0.4.6
google-pasta            0.2.0
grpcio                  1.41.0
h5py                    3.1.0
idna                    3.3
jax                     0.2.22
jaxlib                  0.1.72
keras                   2.6.0
Keras-Preprocessing     1.1.2
kiwisolver              1.3.2
Markdown                3.3.4
matplotlib              3.4.3
mederrata-spmf          0.0.1
natsort                 7.1.1
netCDF4                 1.5.7
numpy                   1.19.5
oauthlib                3.1.1
opt-einsum              3.3.0
packaging               21.0
pandas                  1.1.5
Pillow                  8.3.2
pip                     21.2.4
protobuf                3.18.1
pyasn1                  0.4.8
pyasn1-modules          0.2.8
pymongo                 3.12.0
pyparsing               2.4.7
python-dateutil         2.8.2
pytz                    2021.3
requests                2.26.0
requests-oauthlib       1.3.0
rsa                     4.7.2
scipy                   1.7.1
setuptools              57.4.0
six                     1.15.0
tensorboard             2.6.0
tensorboard-data-server 0.6.1
tensorboard-plugin-wit  1.8.0
tensorflow              2.6.0
tensorflow-addons       0.14.0
tensorflow-estimator    2.6.0
tensorflow-probability  0.14.1
termcolor               1.1.0
tqdm                    4.62.3
typeguard               2.13.0
typing-extensions       3.7.4.3
urllib3                 1.26.7
Werkzeug                2.0.2
wheel                   0.37.0
wrapt                   1.12.1
xarray                  0.19.0
WARNING: You are using pip version 21.2.4; however, version 21.3 is available.
You should consider upgrading via the '/Users/psuedofinnish/git_repo/spmf/venv/bin/python3.9 -m pip install --upgrade pip' command.